### PR TITLE
feat: install nodejs 22 into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@
 # see all versions at https://hub.docker.com/r/oven/bun/tags
 FROM oven/bun:1 AS base
 
+# install Node.js version 22
+RUN apt-get update && apt-get install -y curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs
+
 WORKDIR /usr/src/app
 
 # install dependencies into temp directory


### PR DESCRIPTION
Prisma migrate couldn't generate Prisma client due to the lack of node.js in the Docker image.